### PR TITLE
fix(odas_visualization_node.py): fixed import point_cloud2 for ros2

### DIFF
--- a/odas_ros/scripts/odas_visualization_node.py
+++ b/odas_ros/scripts/odas_visualization_node.py
@@ -10,7 +10,8 @@ import libconf
 
 import std_msgs.msg
 
-import sensor_msgs.point_cloud2 as pcl2  # type: ignore
+from sensor_msgs_py import point_cloud2 as pcl2
+
 from odas_ros_msgs.msg import OdasSstArrayStamped, OdasSslArrayStamped
 from  geometry_msgs.msg import PoseArray, Pose
 from sensor_msgs.msg import PointCloud2, PointField


### PR DESCRIPTION
sensor_msgs_py.point_cloud2 is now used instead of sensor_msgs.point_cloud2 to avoid ModuleNotFoundError in ROS 2 environment